### PR TITLE
修复Page组件中，Content的样式content不和vuepress1.0版本一样的问题

### DIFF
--- a/styles/theme.styl
+++ b/styles/theme.styl
@@ -55,7 +55,7 @@ body
   border-right 1px solid $borderColor
   overflow-y auto
 
-.content__default:not(.custom)
+.content:not(.custom)
   @extend $wrapper
   // > *:first-child
   //   margin-top 1.6rem
@@ -68,7 +68,7 @@ body
   img
     max-width 100%
 
-.content__default.custom
+.content.custom
   padding 0
   margin 0
   img


### PR DESCRIPTION
我看了下vuepress1.0默认主题中content__default已经被修改成content了，自己手动改了下，解决了我的问题。